### PR TITLE
Add three-tier encrypted email delivery

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -1,4 +1,3 @@
-import { ComposeMail } from '@e4a/irmaseal-mail-utils'
 import {
     toEmail,
     hashCon,
@@ -7,6 +6,8 @@ import {
     wasPGEncrypted,
     getLocalFolder,
     type_to_image,
+    buildEncryptedBody,
+    extractArmoredPayload,
 } from './../utils'
 import jwtDecode, { JwtPayload } from 'jwt-decode'
 import { ISealOptions, ISigningKey } from '@e4a/pg-wasm'
@@ -371,15 +372,16 @@ browser.compose.onBeforeSend.addListener(async (tab, details) => {
     // Add the encrypted file attachment
     await browser.compose.addAttachment(tab.id, { file: encryptedFile })
 
-    const compose = new ComposeMail()
-    compose.setSender(details.from)
+    // Build body with armor block + fallback URL
+    const base64Encrypted = Buffer.from(encrypted).toString('base64')
+    const encryptedBody = buildEncryptedBody(details.from, base64Encrypted)
 
     // This doesn't work in onBeforeSend due to a bug, hence we set this
     // when the PostGuard switch is turned on (see messenger.switchbar.onButtonClicked.addListener).
     // details.deliveryFormat = 'both'
 
-    details.plainTextBody = compose.getPlainText()
-    details.body = compose.getHtmlText()
+    details.plainTextBody = 'This email is encrypted with PostGuard. Open it in a PostGuard-compatible client or visit https://postguard.eu/decrypt'
+    details.body = encryptedBody
 
     // Save a copy of the message in the sent folder.
     // 1) Import copy to local sent folder
@@ -472,13 +474,38 @@ async function decryptMessage(msgId: number) {
 
     const attachments = await browser.messages.listAttachments(msg.id)
     const filtered = attachments.filter((att) => att.name === 'postguard.encrypted')
-    if (filtered.length !== 1) return
 
-    const pgPartName = filtered[0].partName
+    let readable: ReadableStream<Uint8Array>
+
+    if (filtered.length === 1) {
+        // Primary: decrypt from attachment
+        const pgPartName = filtered[0].partName
+        const attFile = await browser.messages.getAttachmentFile(msg.id, pgPartName)
+        readable = attFile.stream()
+    } else {
+        // Fallback: extract armored payload from body
+        const full = await browser.messages.getFull(msgId)
+        const bodyHtml = extractBodyHtml(full)
+        if (!bodyHtml) return
+
+        const armoredBase64 = extractArmoredPayload(bodyHtml)
+        if (!armoredBase64) return
+
+        console.log('[PostGuard] Found armored payload in body, length:', armoredBase64.length)
+        const binaryString = atob(armoredBase64)
+        const bytes = new Uint8Array(binaryString.length)
+        for (let i = 0; i < binaryString.length; i++) {
+            bytes[i] = binaryString.charCodeAt(i)
+        }
+        readable = new ReadableStream<Uint8Array>({
+            start(controller) {
+                controller.enqueue(bytes)
+                controller.close()
+            },
+        })
+    }
 
     try {
-        const attFile = await browser.messages.getAttachmentFile(msg.id, pgPartName)
-        const readable = attFile.stream()
         const unsealer = await mod.StreamUnsealer.new(readable, vk)
         const accountId = msg.folder.accountId
         const defaultIdentity = await browser.identities.getDefault(accountId)
@@ -613,6 +640,18 @@ async function decryptMessage(msgId: number) {
         if (e instanceof Error && e.name === 'RecipientUnknownError')
             await notifyDecryptionFailed(i18n('recipientUnknown'))
     }
+}
+
+// Recursively extract HTML body from a MIME message part tree.
+function extractBodyHtml(part: any): string | null {
+    if (part.contentType === 'text/html' && part.body) return part.body
+    if (part.parts) {
+        for (const sub of part.parts) {
+            const found = extractBodyHtml(sub)
+            if (found) return found
+        }
+    }
+    return null
 }
 
 // Cleans up the local storage.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { ComposeMail } from '@e4a/irmaseal-mail-utils'
+
 // Converts a Thunderbird email account identity to an email address
 export function toEmail(identity: string): string {
     const regex = /^(.*)<(.*)>$/
@@ -56,14 +58,121 @@ export async function getLocalFolder(folderName: string) {
 }
 
 export async function isPGEncrypted(msgId: number): Promise<boolean> {
+    // Check attachment first
     const attachments = await browser.messages.listAttachments(msgId)
     const filtered = attachments.filter((att) => att.name === 'postguard.encrypted')
-    return filtered.length === 1
+    if (filtered.length === 1) return true
+
+    // Fallback: check for armor in body
+    try {
+        const full = await browser.messages.getFull(msgId)
+        const bodyHtml = findHtmlBody(full)
+        if (bodyHtml && extractArmoredPayload(bodyHtml)) return true
+    } catch {
+        // ignore
+    }
+
+    return false
+}
+
+function findHtmlBody(part: any): string | null {
+    if (part.contentType === 'text/html' && part.body) return part.body
+    if (part.parts) {
+        for (const sub of part.parts) {
+            const found = findHtmlBody(sub)
+            if (found) return found
+        }
+    }
+    return null
 }
 
 export async function wasPGEncrypted(msgId: number): Promise<boolean> {
     const full = await browser.messages.getFull(msgId)
     return 'x-postguard' in full.headers
+}
+
+// ─── Armor & URL helpers ───────────────────────────────────────────
+
+export const PG_ARMOR_BEGIN = '-----BEGIN POSTGUARD MESSAGE-----'
+export const PG_ARMOR_END = '-----END POSTGUARD MESSAGE-----'
+export const PG_ARMOR_DIV_ID = 'postguard-armor'
+export const POSTGUARD_WEBSITE_URL = 'https://postguard.eu'
+export const PG_MAX_URL_FRAGMENT_SIZE = 100_000
+
+export function armorBase64(base64: string): string {
+    const lines: string[] = []
+    for (let i = 0; i < base64.length; i += 76) {
+        lines.push(base64.substring(i, i + 76))
+    }
+    return `${PG_ARMOR_BEGIN}\n${lines.join('\n')}\n${PG_ARMOR_END}`
+}
+
+export function extractArmoredPayload(html: string): string | null {
+    const regex = new RegExp(
+        PG_ARMOR_BEGIN.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+            '\\s*([A-Za-z0-9+/=\\s]+?)\\s*' +
+            PG_ARMOR_END.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    )
+    const match = html.match(regex)
+    if (!match) return null
+    return match[1].replace(/\s/g, '')
+}
+
+export function toUrlSafeBase64(base64: string): string {
+    return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+export function buildEncryptedBody(senderHtml: string, base64Encrypted: string): string {
+    const compose = new ComposeMail()
+    compose.setSender(senderHtml)
+    let html = compose.getHtmlText()
+
+    let fallbackLinkHtml: string
+    if (base64Encrypted.length <= PG_MAX_URL_FRAGMENT_SIZE) {
+        const urlSafe = toUrlSafeBase64(base64Encrypted)
+        const fallbackUrl = `${POSTGUARD_WEBSITE_URL}/decrypt#${urlSafe}`
+        fallbackLinkHtml =
+            `<div class="outer">` +
+            `<div class="numberCounter">3</div>` +
+            `<div style="margin-left: 34px">` +
+            `Or <a href="${fallbackUrl}">decrypt in your browser</a> ` +
+            `without installing any add-on.` +
+            `</div></div>`
+    } else {
+        fallbackLinkHtml =
+            `<div class="outer">` +
+            `<div class="numberCounter">3</div>` +
+            `<div style="margin-left: 34px">` +
+            `Or decrypt in your browser via ` +
+            `<a href="${POSTGUARD_WEBSITE_URL}/decrypt">postguard.eu/decrypt</a>. ` +
+            `Upload the attached <code>postguard.encrypted</code> file on that page.` +
+            `</div></div>`
+    }
+
+    const armorDiv =
+        `<div id="${PG_ARMOR_DIV_ID}" style="display:none;font-size:0;max-height:0;overflow:hidden;mso-hide:all">` +
+        armorBase64(base64Encrypted) +
+        `</div>`
+
+    const whatIsPostguardMarker = 'What is PostGuard?'
+    const markerIndex = html.indexOf(whatIsPostguardMarker)
+    if (markerIndex !== -1) {
+        const beforeMarker = html.substring(0, markerIndex)
+        const lastOuterDiv = beforeMarker.lastIndexOf(`<div style="`)
+        if (lastOuterDiv !== -1) {
+            const insertionPoint = beforeMarker.lastIndexOf('</div>', lastOuterDiv)
+            if (insertionPoint !== -1) {
+                html =
+                    html.substring(0, insertionPoint) +
+                    fallbackLinkHtml +
+                    html.substring(insertionPoint)
+            }
+        }
+    }
+
+    html = html.replace('</body>', armorDiv + '</body>')
+
+    return html
 }
 
 // If hours <  4: seconds till 4 AM today.


### PR DESCRIPTION
## Summary

- **Inline armor block**: Encrypted payload is now embedded as a PGP-style armored block in a hidden div in the HTML body, in addition to the existing `postguard.encrypted` attachment
- **URL fallback link**: Non-plugin recipients get a clickable link to `postguard.eu/decrypt#<base64data>` for browser-based decryption
- **Body armor decryption fallback**: When no attachment is found, the addon extracts and decrypts from the armored body content
- **Detection updated**: `isPGEncrypted()` now detects both attachment-based and body armor-based encrypted messages

## Context

This brings the Thunderbird addon in line with the Outlook add-in's three-tier delivery approach:
1. **Attachment** (primary) — `postguard.encrypted` file, works reliably in Thunderbird
2. **Inline armor** in a hidden div in the HTML body — backup for when attachments are stripped
3. **URL fallback** — link to the PostGuard website for recipients without any plugin

This ensures interoperability: emails sent from either Outlook or Thunderbird can be decrypted by either client, even if the attachment is lost in transit.

## Test plan

- [ ] Send encrypted email from Thunderbird — verify `postguard.encrypted` attachment is present
- [ ] Inspect sent email source — verify hidden armor div and fallback link in HTML body
- [ ] Receive and decrypt via attachment (existing flow) — still works
- [ ] Receive email with armor in body but no attachment — decrypts from body
- [ ] Receive email sent from Outlook add-in — decrypts successfully
- [ ] Click fallback link in email without plugin — opens PostGuard website and auto-decrypts