### PR TITLE
chore: bump @e4a/pg-js to ^1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "postguard-tb-addon",
       "version": "0.9.3",
       "dependencies": {
-        "@e4a/pg-js": "^0.10.0"
+        "@e4a/pg-js": "^1.1.0"
       },
       "devDependencies": {
         "dotenv": "^17.4.1",
@@ -18,10 +18,9 @@
       }
     },
     "node_modules/@e4a/pg-js": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@e4a/pg-js/-/pg-js-0.10.0.tgz",
-      "integrity": "sha512-R4wFlruxRJLFVp8IWS2XKu+/GzmWgsKeLxE5H1J/+qNuY2GswfWdyD7JLxdDOVOtpdELGTqAQ3aCofSrfGUp5g==",
-      "license": "MIT",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@e4a/pg-js/-/pg-js-1.1.0.tgz",
+      "integrity": "sha512-BpX1PTiAHUIgQTrjYjscJ9RHGq3ymAa+H8wV155k0WwcG5xLQRlBOIfQOdL+FZ+2XHS1ZN9pJTP158naAHBIzQ==",
       "dependencies": {
         "@e4a/pg-wasm": "^0.5.9",
         "@privacybydesign/yivi-client": "^1.0.0-beta.4",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "vitest": "^4.1.3"
   },
   "dependencies": {
-    "@e4a/pg-js": "^0.10.0"
+    "@e4a/pg-js": "^1.1.0"
   }
 }

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -461,9 +461,14 @@ async function handleBeforeSend(tab: { id: number }, details: any) {
         senderAttributes,
       }) as EncryptPopupResult;
 
-      // Only attach the encrypted file if it's under 5 MB
+      // pg-js 1.1.0+ may already decide to skip the attachment in tier 3.
+      // We additionally enforce a stricter 5 MB local cap for Thunderbird
+      // (some SMTP servers refuse messages larger than that).
       const MAX_ATTACHMENT_SIZE = 5 * 1024 * 1024;
-      if (result.attachmentSize <= MAX_ATTACHMENT_SIZE) {
+      if (
+        result.attachmentBase64 != null &&
+        result.attachmentSize <= MAX_ATTACHMENT_SIZE
+      ) {
         const attBytes = fromBase64(result.attachmentBase64);
         const attFile = new File([attBytes as BlobPart], "postguard.encrypted", {
           type: "application/postguard; charset=utf-8",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -50,8 +50,12 @@ export interface EncryptPopupResult {
   subject: string;
   htmlBody: string;
   plainTextBody: string;
-  attachmentBase64: string;
+  /** null in tier 3 — pg-js decided the encrypted payload was too large
+   *  for a local attachment; the body's Cryptify link carries it. */
+  attachmentBase64: string | null;
   attachmentSize: number;
+  tier: "tier1" | "tier2" | "tier3";
+  uploadUuid: string | null;
 }
 
 export interface DecryptPopupResult {

--- a/src/pages/yivi-popup/yivi-popup.ts
+++ b/src/pages/yivi-popup/yivi-popup.ts
@@ -123,8 +123,16 @@ async function handleEncrypt(pg: PostGuard, data: EncryptPopupData, windowId: nu
     senderAttributes: data.senderAttributes?.map((attr) => attr.v),
   });
 
-  // Read the attachment File into base64
-  const attBytes = new Uint8Array(await envelope.attachment.arrayBuffer());
+  // pg-js 1.1.0+: envelope.attachment is null in tier 3 (the encrypted
+  // payload was too large for a local attachment; the body has the
+  // Cryptify download link instead).
+  let attachmentBase64: string | null = null;
+  let attachmentSize = 0;
+  if (envelope.attachment) {
+    const attBytes = new Uint8Array(await envelope.attachment.arrayBuffer());
+    attachmentBase64 = toBase64(attBytes);
+    attachmentSize = attBytes.byteLength;
+  }
 
   await browser.runtime.sendMessage({
     type: "cryptoPopupDone",
@@ -134,8 +142,10 @@ async function handleEncrypt(pg: PostGuard, data: EncryptPopupData, windowId: nu
       subject: envelope.subject,
       htmlBody: envelope.htmlBody,
       plainTextBody: envelope.plainTextBody,
-      attachmentBase64: toBase64(attBytes),
-      attachmentSize: attBytes.byteLength,
+      attachmentBase64,
+      attachmentSize,
+      tier: envelope.tier,
+      uploadUuid: envelope.uploadUuid,
     },
   });
 }


### PR DESCRIPTION
## Summary

Bumps \`@e4a/pg-js\` from \`^0.9.1\` to \`^1.1.0\`. Picks up the three-tier envelope strategy and four other fixes that landed upstream:

- Three-tier \`createEnvelope\` (#34): \`attachment\` is now \`File | null\` — null in tier 3 (payload too large for a local attachment, recipients use the Cryptify link in the body). New \`tier\` and \`uploadUuid\` fields surface the decisions.
- wasm-bindgen dead URL branch stripped at pg-js prebuild (#35) — no consumer-side webpack workaround needed.
- Upload pipeline observes both stream promises (#36) — no more "Uncaught (in promise) undefined" stacks when Cryptify is unreachable.
- Yivi cancellation surfaces as \`YiviSessionError\` instead of a bare string (#37).
- Hosted \`checkmark.png\` image in the email envelope template (#38).

## Code changes for the bump

- \`yivi-popup.ts\` handles \`envelope.attachment === null\` and forwards \`tier\` + \`uploadUuid\` to background.
- \`background.ts\` treats \`attachmentBase64 == null\` as "skip the local attachment" alongside the existing 5 MB Thunderbird-side cap. The cap stays as an additional Thunderbird-specific safety net (SMTP-server defensive).
- \`types.ts\`: \`EncryptPopupResult.attachmentBase64\` is now \`string | null\`; \`tier\` and \`uploadUuid\` added.

## Test plan

- [x] \`npm run build\` succeeds.
- [ ] Manual encrypt-and-send: small text-only message → tier 1, attached locally.
- [ ] Manual encrypt-and-send: ~7 MB attachment → tier 2, attached locally and uploaded to Cryptify.
- [ ] Manual encrypt-and-send: ~12 MB attachment → tier 3, no local attachment, body has Cryptify link.
- [ ] Recipient round-trip via the Outlook add-in (also bumped to 1.1.0) — encrypted attachment decrypts, body link works.