### PR TITLE
chore(deps): bump @e4a/pg-js to ^1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "postguard-tb-addon",
       "version": "0.9.3",
       "dependencies": {
-        "@e4a/pg-js": "^1.3.0"
+        "@e4a/pg-js": "^1.5.0"
       },
       "devDependencies": {
         "dotenv": "^17.4.2",
@@ -18,23 +18,23 @@
       }
     },
     "node_modules/@e4a/pg-js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@e4a/pg-js/-/pg-js-1.3.0.tgz",
-      "integrity": "sha512-0e31LLos0XmXlYZ/TqJb6j1RStzICEmyC8s9qjVgF1w3z4hnnevRq2c0/9XpsZseFi0Vwr6S7GqZoKtqvcd8HQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@e4a/pg-js/-/pg-js-1.5.0.tgz",
+      "integrity": "sha512-yade4VriSbfyyn2+ydK+IaB5KOr24ZQiL7GUDnO3cZEq9XOMY+WhLERBkLcUFBRw8Pi07UxYnr0fti93beP1Cw==",
       "license": "MIT",
       "dependencies": {
-        "@e4a/pg-wasm": "^0.5.9",
-        "@privacybydesign/yivi-client": "^1.0.0-beta.4",
-        "@privacybydesign/yivi-core": "^1.0.0-beta.4",
-        "@privacybydesign/yivi-css": "^1.0.0-beta.4",
-        "@privacybydesign/yivi-web": "^1.0.0-beta.4",
+        "@e4a/pg-wasm": "^0.5.10",
+        "@privacybydesign/yivi-client": "^1.0.0-beta.5",
+        "@privacybydesign/yivi-core": "^1.0.0-beta.5",
+        "@privacybydesign/yivi-css": "^1.0.0-beta.5",
+        "@privacybydesign/yivi-web": "^1.0.0-beta.5",
         "@transcend-io/conflux": "^6.1.3"
       }
     },
     "node_modules/@e4a/pg-wasm": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/@e4a/pg-wasm/-/pg-wasm-0.5.9.tgz",
-      "integrity": "sha512-/K2oDkBVy3pHg4HhWu/UXbnr68ID+MUMsqtO0KwFvfmlQ4EE/sOzRxZgGr2lXCS1zGEwq8c/y2AlsqAP9sd4zg==",
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@e4a/pg-wasm/-/pg-wasm-0.5.10.tgz",
+      "integrity": "sha512-bkxl6/kYIeUMg1/oK6BzXaTZbVO2vLpy9r7d5ODmdryt7CSfPJvR6Xn4GqwJrKrpXN9hC9peL6BQV/anMuxTPA==",
       "license": "MIT"
     },
     "node_modules/@emnapi/core": {
@@ -550,40 +550,40 @@
       }
     },
     "node_modules/@privacybydesign/yivi-client": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-client/-/yivi-client-1.0.0-beta.4.tgz",
-      "integrity": "sha512-1B0NryDau4rkv6w6Y2eLesoynuVvKNEKC/6MZPdPMDo8ecnN02bZM+gpogqO0Th94NKK+iXtRREqKWaopXJhIQ==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-client/-/yivi-client-1.0.0-beta.5.tgz",
+      "integrity": "sha512-9jwOl2r6UidHDTQfDsJD+H6jWZQrWCEfEyrhAMTYautMsfTVKyNgNNP1x9SR7b7A/8u3n5YAarNpGKqX+eApEg==",
       "license": "SEE LICENSE IN REPOSITORY",
       "dependencies": {
         "deepmerge": "^4.2.2"
       },
       "peerDependencies": {
-        "@privacybydesign/yivi-core": "^1.0.0-beta.4"
+        "@privacybydesign/yivi-core": "^1.0.0-beta.5"
       }
     },
     "node_modules/@privacybydesign/yivi-core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-core/-/yivi-core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-xkwTLfVRnGW7RTLjPMvLYbnvYz/ULpZZnzKJwXP9zNdHup0Ol2JGN83dIvq979CtG2vdJUeh8hOoQfPsFaiqnQ==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-core/-/yivi-core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-PvLMOLawmjdt5TWUeTYW3b84RGVn8JpdXdWup7omqs6Lp4POw4AAX6+8GksMbR9Zc8NXEiSgqQqyDOB1W2h5HA==",
       "license": "SEE LICENSE IN REPOSITORY"
     },
     "node_modules/@privacybydesign/yivi-css": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-css/-/yivi-css-1.0.0-beta.4.tgz",
-      "integrity": "sha512-ccV8Wb39gChj9t6nYugYrd5QVvsC9AmQhonsEkBVUX3JQavZVeowTX4Y+VBonJVDfPAvPLaqUdlnVhIDnRLPvA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-css/-/yivi-css-1.0.0-beta.5.tgz",
+      "integrity": "sha512-MsEs7YTEyJshJuhP0mWblRB4bDy0MBxR4ABSMFyNYf2BOXa1SNPcKtxCn4qznG1L2pk1MCI7CRZzBNyCGORg5g==",
       "license": "SEE LICENSE IN REPOSITORY"
     },
     "node_modules/@privacybydesign/yivi-web": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-web/-/yivi-web-1.0.0-beta.4.tgz",
-      "integrity": "sha512-+TMKX1NlHHAD3Lk8MFDcATzDK4muc/1zmyKD3Nwfk8WRb4p2RNNeqwCvztVmZ6V8OVGFFJOT2gMPRv/Z/e2egA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-web/-/yivi-web-1.0.0-beta.5.tgz",
+      "integrity": "sha512-hH3Srygx0GSKsyI7zdZb6fj9cb0A5+qHISiGBLfkzUuASue9lcbdZqqpHV4/jGl15/IcdNwfp/CtlbInow/Clw==",
       "license": "SEE LICENSE IN REPOSITORY",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "qrcode": "^1.4.2"
       },
       "peerDependencies": {
-        "@privacybydesign/yivi-core": "^1.0.0-beta.4"
+        "@privacybydesign/yivi-core": "^1.0.0-beta.5"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "vitest": "^4.1.5"
   },
   "dependencies": {
-    "@e4a/pg-js": "^1.3.0"
+    "@e4a/pg-js": "^1.5.0"
   }
 }


### PR DESCRIPTION
Picks up [encryption4all/postguard-js#52](https://github.com/encryption4all/postguard-js/pull/52) (resumable downloads via Range on transient failures) and [#47](https://github.com/encryption4all/postguard-js/pull/47) (chunk PUT retry/backoff with exponential jitter, surfacing of \`UploadSessionExpiredError\`). Skips 1.4.0 in passing — same SDK lineage, single bump grabs both.

## Public-API note

pg-js's \`downloadFileWithRetry\` now returns the \`ReadableStream\` **synchronously** instead of wrapping it in a Promise. The addon does not call that function directly — it consumes pg-js via \`PostGuard.open()\` / \`Opened.decrypt()\`, which is unchanged. No addon-side code change needed.

Stream-level errors that previously surfaced as a Promise rejection from \`await downloadFileWithRetry\` now surface on the consumer's first \`read()\`. Since the addon's only access path is through \`Opened.decrypt()\`, those errors continue to propagate via the surrounding \`await\`.

## Test plan

- [x] \`npm install\` — resolves to 1.5.0
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run\` — 21 passed (108 todo, pre-existing)
- [x] \`npm run build\` — Build complete
- [ ] Manual: load the addon in Thunderbird against dev cryptify, send + receive an encrypted message and confirm decryption works end-to-end