### PR TITLE
Align pg-js integration with SDK types

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,10 @@
+import type {
+  EnvelopeTier,
+  FriendlySender,
+  PostGuardConfig,
+  RetryOptions,
+} from "@e4a/pg-js";
+
 export interface AttributeRequest {
   t: string;
   v: string;
@@ -13,10 +20,11 @@ export interface Badge {
 
 // --- Crypto popup messaging types ---
 
-export interface CryptoPopupConfig {
-  pkgUrl: string;
-  cryptifyUrl?: string;
+type SerializableRetryOptions = Omit<RetryOptions, "onRetry">;
+
+export interface CryptoPopupConfig extends Omit<PostGuardConfig, "headers" | "retry"> {
   headers?: Record<string, string>;
+  retry?: SerializableRetryOptions;
 }
 
 export interface SerializedRecipient {
@@ -61,14 +69,14 @@ export interface EncryptPopupResult {
    *  for a local attachment; the body's Cryptify link carries it. */
   attachmentBase64: string | null;
   attachmentSize: number;
-  tier: "tier1" | "tier2" | "tier3";
+  tier: EnvelopeTier;
   uploadUuid: string | null;
 }
 
 export interface DecryptPopupResult {
   operation: "decrypt";
   plaintextBase64: string;
-  sender: { email: string | null; attributes: { type: string; value?: string }[] } | null;
+  sender: FriendlySender | null;
 }
 
 export type CryptoPopupResult = EncryptPopupResult | DecryptPopupResult;

--- a/src/pages/yivi-popup/yivi-popup.ts
+++ b/src/pages/yivi-popup/yivi-popup.ts
@@ -2,13 +2,19 @@
 export {};
 
 import { PostGuard, UploadSessionExpiredError } from "@e4a/pg-js";
-import type { DecryptDataResult, DecryptFileResult } from "@e4a/pg-js";
+import type {
+  DecryptDataResult,
+  DecryptFileResult,
+  DecryptResult,
+  Recipient,
+} from "@e4a/pg-js";
 import { toBase64, fromBase64 } from "../../lib/encoding";
 import type {
   CryptoPopupInitData,
   EncryptPopupData,
   DecryptPopupData,
 } from "../../lib/types";
+import { EMAIL_ATTRIBUTE_TYPE } from "../../lib/utils";
 
 // console.log calls are stripped in release builds by esbuild's `pure` option
 
@@ -96,13 +102,13 @@ async function handleEncrypt(pg: PostGuard, data: EncryptPopupData, windowId: nu
   const mimeData = fromBase64(data.mimeDataBase64);
 
   // Rebuild typed recipients from serialized data
-  const recipients = data.recipients.map((r) => {
+  const recipients: Recipient[] = data.recipients.map((r) => {
     const base = r.type === "emailDomain"
       ? pg.recipient.emailDomain(r.email)
       : pg.recipient.email(r.email);
     if (r.policy) {
       for (const attr of r.policy) {
-        if (attr.t !== "pbdf.sidn-pbdf.email.email") {
+        if (attr.t !== EMAIL_ATTRIBUTE_TYPE) {
           base.extraAttribute(attr.t, attr.v);
         }
       }
@@ -182,10 +188,13 @@ async function handleDecrypt(pg: PostGuard, data: DecryptPopupData, windowId: nu
 
   if (data.uuid) {
     const opened = pg.open({ uuid: data.uuid });
-    const result = (await opened.decrypt({
+    const result = await opened.decrypt({
       element: "#yivi-web-form",
       recipient: data.recipientEmail,
-    })) as DecryptFileResult;
+    });
+    if (!isDecryptFileResult(result)) {
+      throw new Error("Expected file decrypt result for uploaded ciphertext");
+    }
     // pg-js's upload pipeline always wraps `data:`-mode payloads as a
     // single-file zip (`data.bin` = the raw MIME) before sealing, so the
     // uuid-mode decrypt yields a zip blob even though our caller used
@@ -197,10 +206,13 @@ async function handleDecrypt(pg: PostGuard, data: DecryptPopupData, windowId: nu
   } else if (data.ciphertextBase64) {
     const ciphertext = fromBase64(data.ciphertextBase64);
     const opened = pg.open({ data: ciphertext });
-    const result = (await opened.decrypt({
+    const result = await opened.decrypt({
       element: "#yivi-web-form",
       recipient: data.recipientEmail,
-    })) as DecryptDataResult;
+    });
+    if (!isDecryptDataResult(result)) {
+      throw new Error("Expected data decrypt result for attached ciphertext");
+    }
     plaintext = result.plaintext;
     sender = result.sender;
   } else {
@@ -216,6 +228,14 @@ async function handleDecrypt(pg: PostGuard, data: DecryptPopupData, windowId: nu
       sender,
     },
   });
+}
+
+function isDecryptFileResult(result: DecryptResult): result is DecryptFileResult {
+  return "blob" in result;
+}
+
+function isDecryptDataResult(result: DecryptResult): result is DecryptDataResult {
+  return "plaintext" in result;
 }
 
 /** Extract a single file from a ZIP blob and return its uncompressed


### PR DESCRIPTION
## Summary

- Use SDK-exported types for the Thunderbird crypto popup bridge: `PostGuardConfig`, `RetryOptions`, `EnvelopeTier`, and `FriendlySender`.
- Type rebuilt recipients as SDK `Recipient` values and reuse the shared email attribute constant.
- Replace direct decrypt result assertions with guarded handling of the SDK `DecryptResult` union.

## Context

Rebased onto current `main` (`@e4a/pg-js` 1.7.1, vitest 4.1.6, CI typecheck step). This follow-up aligns Thunderbird's local integration code with the SDK interface while keeping extension message payloads serializable.

## Validation

- `npm run typecheck`
- `npm run build`
- `npm test`