### PR TITLE
ci: add typecheck step to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Type check
+        run: npm run typecheck
+
       - name: Build extension
         run: npm run build
         env:

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "PostGuard encryption extension for Thunderbird",
   "scripts": {
     "build": "node build.mjs",
+    "typecheck": "tsc --noEmit",
     "build:dev": "node build.mjs --dev",
     "watch": "node build.mjs --dev --watch",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- Adds `typecheck` script to `package.json` (`tsc --noEmit`)
- Adds a "Type check" step in `.github/workflows/build.yml` between install and build, so type errors fail CI before transpile

Closes #104

## Test plan
- [x] `npm run typecheck` passes locally with no errors
- [ ] CI "Type check" step runs and passes on this PR