### PR TITLE
feat(metrics): tag cryptify uploads with X-Cryptify-Source: thunderbird

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -171,6 +171,11 @@ const extVersion = browser.runtime.getManifest().version;
 
 PG_CLIENT_HEADER = {
   "X-PostGuard-Client-Version": `Thunderbird,${tbVersion},pg4tb,${extVersion}`,
+  // Identifies this add-in in cryptify's per-channel upload metrics
+  // (encryption4all/cryptify#102). Explicit header avoids relying on
+  // cryptify's Origin/User-Agent fallbacks, which are environment- and
+  // host-dependent.
+  "X-Cryptify-Source": "thunderbird",
 };
 
 console.log(`[PostGuard] v${extVersion} started (Thunderbird ${tbVersion})`);


### PR DESCRIPTION
## Summary
Adds `X-Cryptify-Source: thunderbird` to `PG_CLIENT_HEADER` so cryptify's per-channel upload metrics ([encryption4all/cryptify#102](https://github.com/encryption4all/cryptify/pull/102)) classify this add-in deterministically rather than via the User-Agent substring fallback.

## Why
cryptify's `detect_channel` walks: explicit `X-Cryptify-Source` → API auth → `Origin` substring → `User-Agent` substring. Thunderbird WebExtensions don't always present a stable `Origin` header (it can be `moz-extension://<uuid>` or null depending on the call site), so the existing path relied on the last-resort User-Agent substring. Setting the header explicitly here removes any environment-dependent ambiguity and is symmetric with parallel PRs in [postguard-website](https://github.com/encryption4all/postguard-website/pull/228) and [postguard-outlook-addon](https://github.com/encryption4all/postguard-outlook-addon/pull/96).

## Test plan
- [x] `npx tsc --noEmit` clean.
- [ ] In a dev Thunderbird with this build loaded, send an encrypted attachment.
- [ ] In Cockpit Grafana Explore on the custom metrics DS: `cryptify_uploads_total{channel="thunderbird"}` should increment by 1.